### PR TITLE
[Patch size] Calculate patch size metrics considering all lines and code lines only

### DIFF
--- a/src/main/java/add/entities/Metrics.java
+++ b/src/main/java/add/entities/Metrics.java
@@ -14,17 +14,29 @@ public class Metrics extends Feature {
     @FeatureAnnotation(key = "nbModifiedMethods", name = "# Modified Methods")
     private int nbModifiedMethods = 0;
 
-    @FeatureAnnotation(key = "addedLines", name = "Added Lines")
-    private int addedLines = 0;
+    @FeatureAnnotation(key = "addedLinesAllLines", name = "Added Lines All Lines")
+    private int addedLinesAllLines = 0;
 
-    @FeatureAnnotation(key = "removedLines", name = "Removed Lines")
-    private int removedLines = 0;
+    @FeatureAnnotation(key = "removedLinesAllLines", name = "Removed Lines All Lines")
+    private int removedLinesAllLines = 0;
 
-    @FeatureAnnotation(key = "modifiedLines", name = "Modified Lines")
-    private int modifiedLines = 0;
+    @FeatureAnnotation(key = "modifiedLinesAllLines", name = "Modified Lines All Lines")
+    private int modifiedLinesAllLines = 0;
 
-    @FeatureAnnotation(key = "patchSize", name = "Patch Size")
-    private int patchSize = 0;
+    @FeatureAnnotation(key = "patchSizeAllLines", name = "Patch Size All Lines")
+    private int patchSizeAllLines = 0;
+
+    @FeatureAnnotation(key = "addedLinesCodeOnly", name = "Added Lines Code Only")
+    private int addedLinesCodeOnly = 0;
+
+    @FeatureAnnotation(key = "removedLinesCodeOnly", name = "Removed Lines Code Only")
+    private int removedLinesCodeOnly = 0;
+
+    @FeatureAnnotation(key = "modifiedLinesCodeOnly", name = "Modified Lines Code Only")
+    private int modifiedLinesCodeOnly = 0;
+
+    @FeatureAnnotation(key = "patchSizeCodeOnly", name = "Patch Size Code Only")
+    private int patchSizeCodeOnly = 0;
 
     @FeatureAnnotation(key = "nbChunks", name = "# Chunks")
     private int nbChunks = 0;

--- a/src/main/java/add/features/detector/repairpatterns/SingleLineDetector.java
+++ b/src/main/java/add/features/detector/repairpatterns/SingleLineDetector.java
@@ -33,7 +33,7 @@ public class SingleLineDetector extends AbstractPatternDetector {
 
         MetricExtractor extractor = new MetricExtractor(this.config);
         Metrics metrics = extractor.analyze();
-        if (metrics.getFeatureCounter("patchSize") == 1) {
+        if (metrics.getFeatureCounter("patchSizeCodeOnly") == 1) {
             wasPatternFound = true;
         } else {
             if (metrics.getFeatureCounter("spreadingCodeOnly") == 0) {
@@ -67,7 +67,7 @@ public class SingleLineDetector extends AbstractPatternDetector {
                 if (this.operations.size() == 1 && this.operations.get(0) instanceof MoveOperation) {
                     CtElement srcNode = this.operations.get(0).getSrcNode();
                     List<CtStatement> statements = srcNode.getElements(new LineFilter());
-                    if (statements.size() == 1 || metrics.getFeatureCounter("patchSize") == 2) {
+                    if (statements.size() == 1 || metrics.getFeatureCounter("patchSizeCodeOnly") == 2) {
                         wasPatternFound = true;
                     }
                 }

--- a/src/main/java/add/features/extractor/MetricExtractor.java
+++ b/src/main/java/add/features/extractor/MetricExtractor.java
@@ -33,7 +33,9 @@ public class MetricExtractor extends FeatureAnalyzer {
 
         this.computeNbModifiedClassesAndMethods(changes, jgitDiffAnalyzer);
 
-        this.computePatchSize(changes, jgitDiffAnalyzer);
+        this.computePatchSize(changes, jgitDiffAnalyzer, false);
+
+        this.computePatchSize(changes, jgitDiffAnalyzer, true);
 
         this.computeNbChunks(changes);
 
@@ -124,7 +126,7 @@ public class MetricExtractor extends FeatureAnalyzer {
     /**
      * Count the number of lines added, removed and modified in the patch
      */
-    public void computePatchSize(Changes changes, JGitBasedDiffAnalyzer jgitDiffAnalyzer) {
+    public void computePatchSize(Changes changes, JGitBasedDiffAnalyzer jgitDiffAnalyzer, boolean codeOnly) {
         int patchAddedLines = 0;
         int patchRemovedLines = 0;
         int patchModifiedLines = 0;
@@ -136,8 +138,10 @@ public class MetricExtractor extends FeatureAnalyzer {
             int addedLines = change.getLength();
             int removedLines = change.getAssociateChange().getLength();
 
-            addedLines -= this.countEmptyAndCommentLines(change, patchedFiles);
-            removedLines -= this.countEmptyAndCommentLines(change.getAssociateChange(), originalFiles);
+            if (codeOnly) {
+                addedLines -= this.countEmptyAndCommentLines(change, patchedFiles);
+                removedLines -= this.countEmptyAndCommentLines(change.getAssociateChange(), originalFiles);
+            }
 
             int chunkAddedLines = 0;
             int chunkRemovedLines = 0;
@@ -159,10 +163,11 @@ public class MetricExtractor extends FeatureAnalyzer {
             patchModifiedLines += chunkModifiedLines;
         }
 
-        this.metrics.setFeatureCounter("addedLines", patchAddedLines);
-        this.metrics.setFeatureCounter("removedLines", patchRemovedLines);
-        this.metrics.setFeatureCounter("modifiedLines", patchModifiedLines);
-        this.metrics.setFeatureCounter("patchSize", patchAddedLines + patchRemovedLines + patchModifiedLines);
+        String name = codeOnly ? "CodeOnly" : "AllLines";
+        this.metrics.setFeatureCounter("addedLines" + name, patchAddedLines);
+        this.metrics.setFeatureCounter("removedLines" + name, patchRemovedLines);
+        this.metrics.setFeatureCounter("modifiedLines" + name, patchModifiedLines);
+        this.metrics.setFeatureCounter("patchSize" + name, patchAddedLines + patchRemovedLines + patchModifiedLines);
     }
 
     /**

--- a/src/test/java/add/features/extractor/MetricExtractorTest.java
+++ b/src/test/java/add/features/extractor/MetricExtractorTest.java
@@ -19,10 +19,10 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(1, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(0, metrics.getFeatureCounter("addedLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLines"));
-        assertEquals(1, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(1, metrics.getFeatureCounter("patchSize"));
+        assertEquals(0, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(1, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(1, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(1, metrics.getFeatureCounter("nbChunks"));
         assertEquals(0, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(0, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -35,10 +35,10 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(1, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(2, metrics.getFeatureCounter("addedLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLines"));
-        assertEquals(0, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(2, metrics.getFeatureCounter("patchSize"));
+        assertEquals(2, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(2, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(2, metrics.getFeatureCounter("nbChunks"));
         assertEquals(8, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(8, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -51,10 +51,10 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(2, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(10, metrics.getFeatureCounter("addedLines"));
-        assertEquals(2, metrics.getFeatureCounter("removedLines"));
-        assertEquals(1, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(13, metrics.getFeatureCounter("patchSize"));
+        assertEquals(10, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(2, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(1, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(13, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(6, metrics.getFeatureCounter("nbChunks"));
         assertEquals(19, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(9, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -67,10 +67,10 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(1, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(2, metrics.getFeatureCounter("addedLines"));
-        assertEquals(1, metrics.getFeatureCounter("removedLines"));
-        assertEquals(2, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(5, metrics.getFeatureCounter("patchSize"));
+        assertEquals(2, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(1, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(2, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(5, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(4, metrics.getFeatureCounter("nbChunks"));
         assertEquals(15, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(9, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -83,10 +83,10 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(1, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(37, metrics.getFeatureCounter("addedLines"));
-        assertEquals(6, metrics.getFeatureCounter("removedLines"));
-        assertEquals(0, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(43, metrics.getFeatureCounter("patchSize"));
+        assertEquals(37, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(6, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(43, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(11, metrics.getFeatureCounter("nbChunks"));
         assertEquals(73, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(48, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -99,10 +99,10 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(2, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(6, metrics.getFeatureCounter("addedLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLines"));
-        assertEquals(0, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(6, metrics.getFeatureCounter("patchSize"));
+        assertEquals(6, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(6, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(2, metrics.getFeatureCounter("nbChunks"));
         assertEquals(0, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(0, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -115,10 +115,10 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(2, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(12, metrics.getFeatureCounter("addedLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLines"));
-        assertEquals(2, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(14, metrics.getFeatureCounter("patchSize"));
+        assertEquals(12, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(2, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(14, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(8, metrics.getFeatureCounter("nbChunks"));
         assertEquals(70, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(26, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -131,10 +131,10 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(1, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(5, metrics.getFeatureCounter("addedLines"));
-        assertEquals(4, metrics.getFeatureCounter("removedLines"));
-        assertEquals(4, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(13, metrics.getFeatureCounter("patchSize"));
+        assertEquals(5, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(4, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(4, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(13, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(8, metrics.getFeatureCounter("nbChunks"));
         assertEquals(17, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(17, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -146,10 +146,10 @@ public class MetricExtractorTest {
 
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
-        assertEquals(7, metrics.getFeatureCounter("addedLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLines"));
-        assertEquals(1, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(8, metrics.getFeatureCounter("patchSize"));
+        assertEquals(7, metrics.getFeatureCounter("addedLinesCodeOnly"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesCodeOnly"));
+        assertEquals(1, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
+        assertEquals(8, metrics.getFeatureCounter("patchSizeCodeOnly"));
     }
 
     @Test
@@ -158,10 +158,10 @@ public class MetricExtractorTest {
 
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
-        assertEquals(3, metrics.getFeatureCounter("addedLines"));
-        assertEquals(4, metrics.getFeatureCounter("removedLines"));
-        assertEquals(3, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(10, metrics.getFeatureCounter("patchSize"));
+        assertEquals(3, metrics.getFeatureCounter("addedLinesCodeOnly"));
+        assertEquals(4, metrics.getFeatureCounter("removedLinesCodeOnly"));
+        assertEquals(3, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
+        assertEquals(10, metrics.getFeatureCounter("patchSizeCodeOnly"));
     }
 
     @Test
@@ -170,10 +170,10 @@ public class MetricExtractorTest {
 
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
-        assertEquals(3, metrics.getFeatureCounter("addedLines"));
-        assertEquals(3, metrics.getFeatureCounter("removedLines"));
-        assertEquals(0, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(6, metrics.getFeatureCounter("patchSize"));
+        assertEquals(3, metrics.getFeatureCounter("addedLinesCodeOnly"));
+        assertEquals(3, metrics.getFeatureCounter("removedLinesCodeOnly"));
+        assertEquals(0, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
+        assertEquals(6, metrics.getFeatureCounter("patchSizeCodeOnly"));
     }
 
     @Test
@@ -182,10 +182,10 @@ public class MetricExtractorTest {
 
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
-        assertEquals(12, metrics.getFeatureCounter("addedLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLines"));
-        assertEquals(2, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(14, metrics.getFeatureCounter("patchSize"));
+        assertEquals(12, metrics.getFeatureCounter("addedLinesCodeOnly"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesCodeOnly"));
+        assertEquals(2, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
+        assertEquals(14, metrics.getFeatureCounter("patchSizeCodeOnly"));
     }
 
     @Test
@@ -194,10 +194,10 @@ public class MetricExtractorTest {
 
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
-        assertEquals(0, metrics.getFeatureCounter("addedLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLines"));
-        assertEquals(2, metrics.getFeatureCounter("modifiedLines"));
-        assertEquals(2, metrics.getFeatureCounter("patchSize"));
+        assertEquals(0, metrics.getFeatureCounter("addedLinesCodeOnly"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesCodeOnly"));
+        assertEquals(2, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
+        assertEquals(2, metrics.getFeatureCounter("patchSizeCodeOnly"));
     }
 
     @Test

--- a/src/test/java/add/features/extractor/PatchSizeMetricsTest.java
+++ b/src/test/java/add/features/extractor/PatchSizeMetricsTest.java
@@ -1,0 +1,181 @@
+package add.features.extractor;
+
+import add.entities.Metrics;
+import add.main.Config;
+import add.utils.TestUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by tdurieux
+ *
+ * Tests for the features:
+ *  - addedLinesAllLines
+ *  - removedLinesAllLines
+ *  - modifiedLinesAllLines
+ *  - patchSizeAllLines
+ *  - addedLinesCodeOnly
+ *  - removedLinesCodeOnly
+ *  - modifiedLinesCodeOnly
+ *  - patchSizeCodeOnly
+ */
+public class PatchSizeMetricsTest {
+
+    @Test
+    public void chart1() {
+        Config config = TestUtils.setupConfig("chart_1");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(0, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(1, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(1, metrics.getFeatureCounter("patchSizeAllLines"));
+    }
+
+    @Test
+    public void chart4() {
+        Config config = TestUtils.setupConfig("chart_4");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(2, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(2, metrics.getFeatureCounter("patchSizeAllLines"));
+    }
+
+    @Test
+    public void chart18() {
+        Config config = TestUtils.setupConfig("chart_18");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(10, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(2, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(1, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(13, metrics.getFeatureCounter("patchSizeAllLines"));
+    }
+
+    @Test
+    public void closure24() {
+        Config config = TestUtils.setupConfig("closure_24");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(2, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(1, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(2, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(5, metrics.getFeatureCounter("patchSizeAllLines"));
+    }
+
+    @Test
+    public void closure76() {
+        Config config = TestUtils.setupConfig("closure_76");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(37, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(6, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(43, metrics.getFeatureCounter("patchSizeAllLines"));
+    }
+
+    @Test
+    public void math4() {
+        Config config = TestUtils.setupConfig("math_4");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(6, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(6, metrics.getFeatureCounter("patchSizeAllLines"));
+    }
+
+    @Test
+    public void time12() {
+        Config config = TestUtils.setupConfig("time_12");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(12, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(2, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(14, metrics.getFeatureCounter("patchSizeAllLines"));
+    }
+
+    @Test
+    public void time23() {
+        Config config = TestUtils.setupConfig("time_23");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(5, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(4, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(4, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(13, metrics.getFeatureCounter("patchSizeAllLines"));
+    }
+
+    @Test
+    public void accumulo13eb19c2() {
+        Config config = TestUtils.setupConfig("accumulo_13eb19c2");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(7, metrics.getFeatureCounter("addedLinesCodeOnly"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesCodeOnly"));
+        assertEquals(1, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
+        assertEquals(8, metrics.getFeatureCounter("patchSizeCodeOnly"));
+    }
+
+    @Test
+    public void accumulo17344890() {
+        Config config = TestUtils.setupConfig("accumulo_17344890");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(3, metrics.getFeatureCounter("addedLinesCodeOnly"));
+        assertEquals(4, metrics.getFeatureCounter("removedLinesCodeOnly"));
+        assertEquals(3, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
+        assertEquals(10, metrics.getFeatureCounter("patchSizeCodeOnly"));
+    }
+
+    @Test
+    public void bears5() {
+        Config config = TestUtils.setupConfig("bears_5");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(3, metrics.getFeatureCounter("addedLinesCodeOnly"));
+        assertEquals(3, metrics.getFeatureCounter("removedLinesCodeOnly"));
+        assertEquals(0, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
+        assertEquals(6, metrics.getFeatureCounter("patchSizeCodeOnly"));
+    }
+
+    @Test
+    public void bears140() {
+        Config config = TestUtils.setupConfig("bears_140");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(12, metrics.getFeatureCounter("addedLinesCodeOnly"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesCodeOnly"));
+        assertEquals(2, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
+        assertEquals(14, metrics.getFeatureCounter("patchSizeCodeOnly"));
+    }
+
+    @Test
+    public void bears144() {
+        Config config = TestUtils.setupConfig("bears_144");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(0, metrics.getFeatureCounter("addedLinesCodeOnly"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesCodeOnly"));
+        assertEquals(2, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
+        assertEquals(2, metrics.getFeatureCounter("patchSizeCodeOnly"));
+    }
+
+}

--- a/src/test/java/add/features/extractor/PatchSizeMetricsTest.java
+++ b/src/test/java/add/features/extractor/PatchSizeMetricsTest.java
@@ -22,68 +22,10 @@ import static org.junit.Assert.assertEquals;
  */
 public class PatchSizeMetricsTest {
 
-    @Test
-    public void chart1() {
-        Config config = TestUtils.setupConfig("chart_1");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(0, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(1, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(1, metrics.getFeatureCounter("patchSizeAllLines"));
-    }
+    // BEGINNING of tests on patch size metrics considering ALL LINES
 
     @Test
-    public void chart4() {
-        Config config = TestUtils.setupConfig("chart_4");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(2, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(2, metrics.getFeatureCounter("patchSizeAllLines"));
-    }
-
-    @Test
-    public void chart18() {
-        Config config = TestUtils.setupConfig("chart_18");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(10, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(2, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(1, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(13, metrics.getFeatureCounter("patchSizeAllLines"));
-    }
-
-    @Test
-    public void closure24() {
-        Config config = TestUtils.setupConfig("closure_24");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(2, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(1, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(2, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(5, metrics.getFeatureCounter("patchSizeAllLines"));
-    }
-
-    @Test
-    public void closure76() {
-        Config config = TestUtils.setupConfig("closure_76");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(37, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(6, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(43, metrics.getFeatureCounter("patchSizeAllLines"));
-    }
-
-    @Test
-    public void math4() {
+    public void testPatchSizeOnlyWithAddedLinesAllLines_math4() {
         Config config = TestUtils.setupConfig("math_4");
 
         MetricExtractor extractor = new MetricExtractor(config);
@@ -95,19 +37,43 @@ public class PatchSizeMetricsTest {
     }
 
     @Test
-    public void time12() {
-        Config config = TestUtils.setupConfig("time_12");
+    public void testPatchSizeOnlyWithRemovedLinesAllLines_math50() {
+        Config config = TestUtils.setupConfig("math_50");
 
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
-        assertEquals(12, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(2, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(14, metrics.getFeatureCounter("patchSizeAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(4, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(4, metrics.getFeatureCounter("patchSizeAllLines"));
     }
 
     @Test
-    public void time23() {
+    public void testPatchSizeOnlyWithModifiedLinesAllLines_chart1() {
+        Config config = TestUtils.setupConfig("chart_1");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(0, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(1, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(1, metrics.getFeatureCounter("patchSizeAllLines"));
+    }
+
+    @Test
+    public void testPatchSizeAllLines_closure24() {
+        Config config = TestUtils.setupConfig("closure_24");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(2, metrics.getFeatureCounter("addedLinesAllLines"));
+        assertEquals(1, metrics.getFeatureCounter("removedLinesAllLines"));
+        assertEquals(2, metrics.getFeatureCounter("modifiedLinesAllLines"));
+        assertEquals(5, metrics.getFeatureCounter("patchSizeAllLines"));
+    }
+
+    @Test
+    public void testPatchSizeAllLines_time23() {
         Config config = TestUtils.setupConfig("time_23");
 
         MetricExtractor extractor = new MetricExtractor(config);
@@ -118,8 +84,26 @@ public class PatchSizeMetricsTest {
         assertEquals(13, metrics.getFeatureCounter("patchSizeAllLines"));
     }
 
+    // END of tests on patch size metrics considering ALL LINES
+
+    // BEGINNING of tests on patch size metrics considering CODE ONLY
+
+    // Lines of code were commented
     @Test
-    public void accumulo13eb19c2() {
+    public void testPatchSizeCodeOnly_math38() {
+        Config config = TestUtils.setupConfig("math_38");
+
+        MetricExtractor extractor = new MetricExtractor(config);
+        Metrics metrics = extractor.analyze();
+        assertEquals(0, metrics.getFeatureCounter("addedLinesCodeOnly"));
+        assertEquals(2, metrics.getFeatureCounter("removedLinesCodeOnly"));
+        assertEquals(2, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
+        assertEquals(4, metrics.getFeatureCounter("patchSizeCodeOnly"));
+    }
+
+    // Deletion of an empty line and addition of a single line comment
+    @Test
+    public void testPatchSizeCodeOnly_accumulo13eb19c2() {
         Config config = TestUtils.setupConfig("accumulo_13eb19c2");
 
         MetricExtractor extractor = new MetricExtractor(config);
@@ -130,20 +114,9 @@ public class PatchSizeMetricsTest {
         assertEquals(8, metrics.getFeatureCounter("patchSizeCodeOnly"));
     }
 
+    // Addition of single line comments
     @Test
-    public void accumulo17344890() {
-        Config config = TestUtils.setupConfig("accumulo_17344890");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(3, metrics.getFeatureCounter("addedLinesCodeOnly"));
-        assertEquals(4, metrics.getFeatureCounter("removedLinesCodeOnly"));
-        assertEquals(3, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
-        assertEquals(10, metrics.getFeatureCounter("patchSizeCodeOnly"));
-    }
-
-    @Test
-    public void bears5() {
+    public void testPatchSizeCodeOnly_bears5() {
         Config config = TestUtils.setupConfig("bears_5");
 
         MetricExtractor extractor = new MetricExtractor(config);
@@ -154,8 +127,9 @@ public class PatchSizeMetricsTest {
         assertEquals(6, metrics.getFeatureCounter("patchSizeCodeOnly"));
     }
 
+    // Single and non-single comments, addition of empty lines
     @Test
-    public void bears140() {
+    public void testPatchSizeCodeOnly_bears140() {
         Config config = TestUtils.setupConfig("bears_140");
 
         MetricExtractor extractor = new MetricExtractor(config);
@@ -166,16 +140,5 @@ public class PatchSizeMetricsTest {
         assertEquals(14, metrics.getFeatureCounter("patchSizeCodeOnly"));
     }
 
-    @Test
-    public void bears144() {
-        Config config = TestUtils.setupConfig("bears_144");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(0, metrics.getFeatureCounter("addedLinesCodeOnly"));
-        assertEquals(0, metrics.getFeatureCounter("removedLinesCodeOnly"));
-        assertEquals(2, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
-        assertEquals(2, metrics.getFeatureCounter("patchSizeCodeOnly"));
-    }
-
+    // END of tests on patch size metrics considering CODE ONLY
 }

--- a/src/test/java/add/features/extractor/PatchSpreadingMetricsTest.java
+++ b/src/test/java/add/features/extractor/PatchSpreadingMetricsTest.java
@@ -8,9 +8,17 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Created by tdurieux
+ * Created by fermadeiral
+ *
+ * Tests for the features:
+ *  - nbChunks
+ *  - spreadingAllLines
+ *  - spreadingCodeOnly
+ *  - nbFiles
+ *  - nbModifiedClasses
+ *  - nbModifiedMethods
  */
-public class MetricExtractorTest {
+public class PatchSpreadingMetricsTest {
 
     @Test
     public void chart1() {
@@ -19,10 +27,6 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(1, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(0, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(1, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(1, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(1, metrics.getFeatureCounter("nbChunks"));
         assertEquals(0, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(0, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -35,10 +39,6 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(1, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(2, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(2, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(2, metrics.getFeatureCounter("nbChunks"));
         assertEquals(8, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(8, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -51,10 +51,6 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(2, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(10, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(2, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(1, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(13, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(6, metrics.getFeatureCounter("nbChunks"));
         assertEquals(19, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(9, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -67,10 +63,6 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(1, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(2, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(1, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(2, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(5, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(4, metrics.getFeatureCounter("nbChunks"));
         assertEquals(15, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(9, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -83,10 +75,6 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(1, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(37, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(6, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(43, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(11, metrics.getFeatureCounter("nbChunks"));
         assertEquals(73, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(48, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -99,10 +87,6 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(2, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(6, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(6, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(2, metrics.getFeatureCounter("nbChunks"));
         assertEquals(0, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(0, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -115,10 +99,6 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(2, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(12, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(0, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(2, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(14, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(8, metrics.getFeatureCounter("nbChunks"));
         assertEquals(70, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(26, metrics.getFeatureCounter("spreadingCodeOnly"));
@@ -131,73 +111,9 @@ public class MetricExtractorTest {
         MetricExtractor extractor = new MetricExtractor(config);
         Metrics metrics = extractor.analyze();
         assertEquals(1, metrics.getFeatureCounter("nbFiles"));
-        assertEquals(5, metrics.getFeatureCounter("addedLinesAllLines"));
-        assertEquals(4, metrics.getFeatureCounter("removedLinesAllLines"));
-        assertEquals(4, metrics.getFeatureCounter("modifiedLinesAllLines"));
-        assertEquals(13, metrics.getFeatureCounter("patchSizeAllLines"));
         assertEquals(8, metrics.getFeatureCounter("nbChunks"));
         assertEquals(17, metrics.getFeatureCounter("spreadingAllLines"));
         assertEquals(17, metrics.getFeatureCounter("spreadingCodeOnly"));
-    }
-
-    @Test
-    public void accumulo13eb19c2() {
-        Config config = TestUtils.setupConfig("accumulo_13eb19c2");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(7, metrics.getFeatureCounter("addedLinesCodeOnly"));
-        assertEquals(0, metrics.getFeatureCounter("removedLinesCodeOnly"));
-        assertEquals(1, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
-        assertEquals(8, metrics.getFeatureCounter("patchSizeCodeOnly"));
-    }
-
-    @Test
-    public void accumulo17344890() {
-        Config config = TestUtils.setupConfig("accumulo_17344890");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(3, metrics.getFeatureCounter("addedLinesCodeOnly"));
-        assertEquals(4, metrics.getFeatureCounter("removedLinesCodeOnly"));
-        assertEquals(3, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
-        assertEquals(10, metrics.getFeatureCounter("patchSizeCodeOnly"));
-    }
-
-    @Test
-    public void bears5() {
-        Config config = TestUtils.setupConfig("bears_5");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(3, metrics.getFeatureCounter("addedLinesCodeOnly"));
-        assertEquals(3, metrics.getFeatureCounter("removedLinesCodeOnly"));
-        assertEquals(0, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
-        assertEquals(6, metrics.getFeatureCounter("patchSizeCodeOnly"));
-    }
-
-    @Test
-    public void bears140() {
-        Config config = TestUtils.setupConfig("bears_140");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(12, metrics.getFeatureCounter("addedLinesCodeOnly"));
-        assertEquals(0, metrics.getFeatureCounter("removedLinesCodeOnly"));
-        assertEquals(2, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
-        assertEquals(14, metrics.getFeatureCounter("patchSizeCodeOnly"));
-    }
-
-    @Test
-    public void bears144() {
-        Config config = TestUtils.setupConfig("bears_144");
-
-        MetricExtractor extractor = new MetricExtractor(config);
-        Metrics metrics = extractor.analyze();
-        assertEquals(0, metrics.getFeatureCounter("addedLinesCodeOnly"));
-        assertEquals(0, metrics.getFeatureCounter("removedLinesCodeOnly"));
-        assertEquals(2, metrics.getFeatureCounter("modifiedLinesCodeOnly"));
-        assertEquals(2, metrics.getFeatureCounter("patchSizeCodeOnly"));
     }
 
     @Test


### PR DESCRIPTION
Since commit b86104749df1a368f25737af8c25b0ae5ec743d1, ADD has calculated the four patch size metrics (i.e. addedLines, removedLines, modifiedLines, and patchSize) discarding empty and comment lines. However, I found that this created a diff between the results on patch size reported in the Defects4J dissection (SANER'18 paper) with the results generated by ADD.

For that reason, this PR adds the feature of calculating the four metrics in both ways, i.e. considering all lines and code only (where empty and comment lines are discarded). This results in eight metrics on patch size:

- addedLinesAllLines
- removedLinesAllLines
- modifiedLinesAllLines
- patchSizeAllLines

- addedLinesCodeOnly
- removedLinesCodeOnly
- modifiedLinesCodeOnly
- patchSizeCodeOnly